### PR TITLE
linker: Add support for dynamic SHIM libraries

### DIFF
--- a/libc/dns/net/hosts_cache.c
+++ b/libc/dns/net/hosts_cache.c
@@ -1,0 +1,551 @@
+/*
+ * Copyright (C) 2016 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fcntl.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <strings.h>
+#include <sys/file.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <utime.h>
+#include <pthread.h>
+
+#include <netinet/in6.h>
+#include <arpa/inet.h>
+
+#include "hostent.h"
+#include "resolv_private.h"
+
+#define MAX_ADDRLEN	(INET6_ADDRSTRLEN - (1 + 5))
+#define MAX_HOSTLEN	MAXHOSTNAMELEN
+
+#define ESTIMATED_LINELEN	32
+#define HCFILE_ALLOC_SIZE	256
+
+/* From sethostent.c */
+#define ALIGNBYTES	(sizeof(uintptr_t) - 1)
+#define ALIGN(p)	(((uintptr_t)(p) + ALIGNBYTES) &~ ALIGNBYTES)
+
+/*
+ * Host cache entry for hcfile.c_data.
+ * Offsets are into hcfile.h_data.
+ * Strings are *not* terminated by NULL, but by whitespace (isspace) or '#'.
+ * Use hstr* functions with these.
+ */
+struct hcent
+{
+	uint32_t	addr;
+	uint32_t	name;
+};
+
+/*
+ * Overall host cache file state.
+ */
+struct hcfile
+{
+	int		h_fd;
+	struct stat	h_st;
+	char		*h_data;
+
+	uint32_t	c_alloc;
+	uint32_t	c_len;
+	struct hcent	*c_data;
+};
+static struct hcfile hcfile;
+static pthread_mutex_t hclock = PTHREAD_MUTEX_INITIALIZER;
+
+static size_t hstrlen(const char *s)
+{
+	const char *p = s;
+	while (*p && *p != '#' && !isspace(*p))
+		++p;
+	return p - s;
+}
+
+static int hstrcmp(const char *a, const char *b)
+{
+	size_t alen = hstrlen(a);
+	size_t blen = hstrlen(b);
+	int res = strncmp(a, b, MIN(alen, blen));
+	if (res == 0)
+		res = alen - blen;
+	return res;
+}
+
+static char *hstrcpy(char *dest, const char *src)
+{
+	size_t len = hstrlen(src);
+	memcpy(dest, src, len);
+	dest[len] = '\0';
+	return dest;
+}
+
+static char *hstrdup(const char *s)
+{
+	size_t len = hstrlen(s);
+	char *dest = (char *)malloc(len + 1);
+	if (!dest)
+		return NULL;
+	memcpy(dest, s, len);
+	dest[len] = '\0';
+	return dest;
+}
+
+static int cmp_hcent_name(const void *a, const void *b)
+{
+	struct hcent *ea = (struct hcent *)a;
+	const char *na = hcfile.h_data + ea->name;
+	struct hcent *eb = (struct hcent *)b;
+	const char *nb = hcfile.h_data + eb->name;
+
+	return hstrcmp(na, nb);
+}
+
+static struct hcent *_hcfindname_exact(const char *name)
+{
+	size_t first, last, mid;
+	struct hcent *cur = NULL;
+	int cmp;
+
+	if (hcfile.c_len == 0)
+		return NULL;
+
+	first = 0;
+	last = hcfile.c_len - 1;
+	mid = (first + last) / 2;
+	while (first <= last) {
+		cur = hcfile.c_data + mid;
+		cmp = hstrcmp(hcfile.h_data + cur->name, name);
+		if (cmp == 0)
+			goto found;
+		if (cmp < 0)
+			first = mid + 1;
+		else {
+			if (mid > 0)
+				last = mid - 1;
+			else
+				return NULL;
+		}
+		mid = (first + last) / 2;
+	}
+	return NULL;
+
+found:
+	while (cur > hcfile.c_data) {
+		struct hcent *prev = cur - 1;
+		cmp = cmp_hcent_name(cur, prev);
+		if (cmp)
+			break;
+		cur = prev;
+	}
+
+	return cur;
+}
+
+static struct hcent *_hcfindname(const char *name)
+{
+	struct hcent *ent;
+	char namebuf[MAX_HOSTLEN];
+	char *p;
+	char *dot;
+
+	ent = _hcfindname_exact(name);
+	if (!ent && strlen(name) < sizeof(namebuf)) {
+		strcpy(namebuf, name);
+		p = namebuf;
+		do {
+			dot = strchr(p, '.');
+			if (!dot)
+				break;
+			if (dot > p) {
+				*(dot - 1) = '*';
+				ent = _hcfindname_exact(dot - 1);
+			}
+			p = dot + 1;
+		}
+		while (!ent);
+	}
+
+	return ent;
+}
+
+/*
+ * Find next name on line, if any.
+ *
+ * Assumes that line is terminated by LF.
+ */
+static const char *_hcnextname(const char *name)
+{
+	while (!isspace(*name)) {
+		if (*name == '#')
+			return NULL;
+		++name;
+	}
+	while (isspace(*name)) {
+		if (*name == '\n')
+			return NULL;
+		++name;
+	}
+	if (*name == '#')
+		return NULL;
+	return name;
+}
+
+static int _hcfilemmap(void)
+{
+	struct stat st;
+	int h_fd;
+	char *h_addr;
+	const char *p, *pend;
+	uint32_t c_alloc;
+
+	h_fd = open(_PATH_HOSTS, O_RDONLY);
+	if (h_fd < 0)
+		return -1;
+	if (flock(h_fd, LOCK_EX) != 0) {
+		close(h_fd);
+		return -1;
+	}
+
+	if (hcfile.h_data) {
+		memset(&st, 0, sizeof(st));
+		if (fstat(h_fd, &st) == 0) {
+			if (st.st_size == hcfile.h_st.st_size &&
+			    st.st_mtime == hcfile.h_st.st_mtime) {
+				flock(h_fd, LOCK_UN);
+				close(h_fd);
+				return 0;
+			}
+		}
+		free(hcfile.c_data);
+		munmap(hcfile.h_data, hcfile.h_st.st_size);
+		close(hcfile.h_fd);
+		memset(&hcfile, 0, sizeof(struct hcfile));
+	}
+
+	if (fstat(h_fd, &st) != 0) {
+		flock(h_fd, LOCK_UN);
+		close(h_fd);
+		return -1;
+	}
+	h_addr = mmap(NULL, st.st_size, PROT_READ, MAP_SHARED, h_fd, 0);
+	if (h_addr == MAP_FAILED) {
+		flock(h_fd, LOCK_UN);
+		close(h_fd);
+		return -1;
+	}
+
+	hcfile.h_fd = h_fd;
+	hcfile.h_st = st;
+	hcfile.h_data = h_addr;
+
+	c_alloc = 0;
+	/*
+	 * Do an initial allocation if the file is "large".  Estimate
+	 * 32 bytes per line and define "large" as more than half of
+	 * the alloc growth size (256 entries).
+	 */
+	if (st.st_size >= ESTIMATED_LINELEN * HCFILE_ALLOC_SIZE / 2) {
+		c_alloc = st.st_size / ESTIMATED_LINELEN;
+		hcfile.c_data = malloc(c_alloc * sizeof(struct hcent));
+		if (!hcfile.c_data) {
+			goto oom;
+		}
+	}
+
+	p = (const char *)h_addr;
+	pend = p + st.st_size;
+	while (p < pend) {
+		const char *eol, *addr, *name;
+		size_t len;
+		addr = p;
+		eol = memchr(p, '\n', pend - p);
+		if (!eol)
+			break;
+		p = eol + 1;
+		if (*addr == '#' || *addr == '\n')
+			continue;
+		len = hstrlen(addr);
+		if (len > MAX_ADDRLEN)
+			continue;
+		name = addr + len;
+		while (name < eol && isspace(*name))
+			++name;
+		while (name < eol) {
+			len = hstrlen(name);
+			if (len == 0)
+				break;
+			if (len < MAX_HOSTLEN) {
+				struct hcent *ent;
+				if (c_alloc <= hcfile.c_len) {
+					struct hcent *c_data;
+					c_alloc += HCFILE_ALLOC_SIZE;
+					c_data = realloc(hcfile.c_data, c_alloc * sizeof(struct hcent));
+					if (!c_data) {
+						goto oom;
+					}
+					hcfile.c_data = c_data;
+				}
+				ent = hcfile.c_data + hcfile.c_len;
+				ent->addr = addr - h_addr;
+				ent->name = name - h_addr;
+				++hcfile.c_len;
+			}
+			name += len;
+			while (name < eol && isspace(*name))
+				++name;
+		}
+	}
+
+	qsort(hcfile.c_data, hcfile.c_len,
+	    sizeof(struct hcent), cmp_hcent_name);
+
+	flock(h_fd, LOCK_UN);
+
+	return 0;
+
+oom:
+	free(hcfile.c_data);
+	munmap(hcfile.h_data, hcfile.h_st.st_size);
+	flock(hcfile.h_fd, LOCK_UN);
+	close(hcfile.h_fd);
+	memset(&hcfile, 0, sizeof(struct hcfile));
+	return -1;
+}
+
+/*
+ * Caching version of getaddrinfo.
+ *
+ * If we find the requested host name in the cache, use getaddrinfo to
+ * populate the result for each address we find.
+ *
+ * Note glibc and bionic differ in the handling of ai_canonname.  POSIX
+ * says that ai_canonname is only populated in the first result entry.
+ * glibc does this.  bionic populates ai_canonname in all result entries.
+ * We choose the POSIX/glibc way here.
+ */
+int hc_getaddrinfo(const char *host, const char *service,
+		   const struct addrinfo *hints,
+		   struct addrinfo **result)
+{
+	int ret = 0;
+	struct hcent *ent, *cur;
+	struct addrinfo *ai;
+	struct addrinfo rhints;
+	struct addrinfo *last;
+	int canonname = 0;
+	int cmp;
+
+	if (getenv("ANDROID_HOSTS_CACHE_DISABLE") != NULL)
+		return EAI_SYSTEM;
+
+	/* Avoid needless work and recursion */
+	if (hints && (hints->ai_flags & AI_NUMERICHOST))
+		return EAI_SYSTEM;
+	if (!host)
+		return EAI_SYSTEM;
+
+	pthread_mutex_lock(&hclock);
+
+	if (_hcfilemmap() != 0) {
+		ret = EAI_SYSTEM;
+		goto out;
+	}
+	ent = _hcfindname(host);
+	if (!ent) {
+		ret = EAI_NONAME;
+		goto out;
+	}
+
+	if (hints) {
+		canonname = (hints->ai_flags & AI_CANONNAME);
+		memcpy(&rhints, hints, sizeof(rhints));
+		rhints.ai_flags &= ~AI_CANONNAME;
+	}
+	else {
+		memset(&rhints, 0, sizeof(rhints));
+	}
+	rhints.ai_flags |= AI_NUMERICHOST;
+
+	last = NULL;
+	cur = ent;
+	do {
+		char addrstr[MAX_ADDRLEN];
+		struct addrinfo *res;
+
+		hstrcpy(addrstr, hcfile.h_data + cur->addr);
+
+		if (getaddrinfo(addrstr, service, &rhints, &res) == 0) {
+			if (!last)
+				(*result)->ai_next = res;
+			else
+				last->ai_next = res;
+			last = res;
+			while (last->ai_next)
+				last = last->ai_next;
+		}
+
+		if(cur + 1 >= hcfile.c_data + hcfile.c_len)
+			break;
+		cmp = cmp_hcent_name(cur, cur + 1);
+		cur = cur + 1;
+	}
+	while (!cmp);
+
+	if (last == NULL) {
+		/* This check is equivalent to (*result)->ai_next == NULL */
+		ret = EAI_NODATA;
+		goto out;
+	}
+
+	if (canonname) {
+		ai = (*result)->ai_next;
+		free(ai->ai_canonname);
+		ai->ai_canonname = hstrdup(hcfile.h_data + ent->name);
+	}
+
+out:
+	pthread_mutex_unlock(&hclock);
+	return ret;
+}
+
+/*
+ * Caching version of gethtbyname.
+ *
+ * Note glibc and bionic differ in the handling of aliases.  glibc returns
+ * all aliases for all entries, regardless of whether they match h_addrtype.
+ * bionic returns only the aliases for the first hosts entry.  We return all
+ * aliases for all IPv4 entries.
+ *
+ * Additionally, if an alias is IPv6 and the primary name for an alias also
+ * has an IPv4 entry, glibc will return the IPv4 address(es), but bionic
+ * will not.  Neither do we.
+ */
+int hc_gethtbyname(const char *host, int af, struct getnamaddr *info)
+{
+	int ret = NETDB_SUCCESS;
+	struct hcent *ent, *cur;
+	int cmp;
+	size_t addrlen;
+	unsigned int naliases = 0;
+	char *aliases[MAXALIASES];
+	unsigned int naddrs = 0;
+	char *addr_ptrs[MAXADDRS];
+	unsigned int n;
+
+	if (getenv("ANDROID_HOSTS_CACHE_DISABLE") != NULL)
+		return NETDB_INTERNAL;
+
+	switch (af) {
+	case AF_INET:  addrlen = NS_INADDRSZ;  break;
+	case AF_INET6: addrlen = NS_IN6ADDRSZ; break;
+	default:
+		return NETDB_INTERNAL;
+	}
+
+	pthread_mutex_lock(&hclock);
+
+	if (_hcfilemmap() != 0) {
+		ret = NETDB_INTERNAL;
+		goto out;
+	}
+
+	ent = _hcfindname(host);
+	if (!ent) {
+		ret = HOST_NOT_FOUND;
+		goto out;
+	}
+
+	cur = ent;
+	do {
+		char addr[16];
+		char addrstr[MAX_ADDRLEN];
+		char namestr[MAX_HOSTLEN];
+		const char *name;
+
+		hstrcpy(addrstr, hcfile.h_data + cur->addr);
+		if (inet_pton(af, addrstr, &addr) == 1) {
+			char *aligned;
+			/* First match is considered the official hostname */
+			if (naddrs == 0) {
+				hstrcpy(namestr, hcfile.h_data + cur->name);
+				HENT_SCOPY(info->hp->h_name, namestr, info->buf, info->buflen);
+			}
+			for (name = hcfile.h_data + cur->name; name; name = _hcnextname(name)) {
+				if (!hstrcmp(name, host))
+					continue;
+				hstrcpy(namestr, name);
+				HENT_SCOPY(aliases[naliases], namestr, info->buf, info->buflen);
+				++naliases;
+				if (naliases >= MAXALIASES)
+					goto nospc;
+			}
+			aligned = (char *)ALIGN(info->buf);
+			if (info->buf != aligned) {
+				if ((ptrdiff_t)info->buflen < (aligned - info->buf))
+					goto nospc;
+				info->buflen -= (aligned - info->buf);
+				info->buf = aligned;
+			}
+			HENT_COPY(addr_ptrs[naddrs], addr, addrlen, info->buf, info->buflen);
+			++naddrs;
+			if (naddrs >= MAXADDRS)
+				goto nospc;
+		}
+
+		if(cur + 1 >= hcfile.c_data + hcfile.c_len)
+			break;
+		cmp = cmp_hcent_name(cur, cur + 1);
+		cur = cur + 1;
+	}
+	while (!cmp);
+
+	if (naddrs == 0) {
+		ret = HOST_NOT_FOUND;
+		goto out;
+	}
+
+	addr_ptrs[naddrs++] = NULL;
+	aliases[naliases++] = NULL;
+
+	/* hp->h_name already populated */
+	HENT_ARRAY(info->hp->h_aliases, naliases, info->buf, info->buflen);
+	for (n = 0; n < naliases; ++n) {
+		info->hp->h_aliases[n] = aliases[n];
+	}
+	info->hp->h_addrtype = af;
+	info->hp->h_length = addrlen;
+	HENT_ARRAY(info->hp->h_addr_list, naddrs, info->buf, info->buflen);
+	for (n = 0; n < naddrs; ++n) {
+		info->hp->h_addr_list[n] = addr_ptrs[n];
+	}
+
+out:
+	pthread_mutex_unlock(&hclock);
+	*info->he = ret;
+	return ret;
+
+nospc:
+	ret = NETDB_INTERNAL;
+	goto out;
+}

--- a/libc/dns/net/hosts_cache.h
+++ b/libc/dns/net/hosts_cache.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+struct getnamaddr;
+
+int hc_getaddrinfo(const char *host, const char *service,
+		   const struct addrinfo *hints,
+		   struct addrinfo **result);
+
+int hc_gethtbyname(const char *host, int af, struct getnamaddr *info);

--- a/linker/Android.bp
+++ b/linker/Android.bp
@@ -91,6 +91,11 @@ cc_defaults {
         debuggable: {
             cppflags: ["-DUSE_LD_CONFIG_FILE"],
         },
+        stormbreaker: {
+            target_shim_libs: {
+                cppflags: ["-DLD_SHIM_LIBS=\"%s\""],
+            },
+        },
     },
 
     cppflags: ["-Wold-style-cast"],

--- a/linker/linker.cpp
+++ b/linker/linker.cpp
@@ -644,6 +644,68 @@ enum walk_action_result_t : uint32_t {
   kWalkSkip = 2
 };
 
+#ifdef LD_SHIM_LIBS
+// g_ld_all_shim_libs maintains the references to memory as it used
+// in the soinfo structures and in the g_active_shim_libs list.
+
+static std::vector<ShimDescriptor> g_ld_all_shim_libs;
+
+// g_active_shim_libs are all shim libs that are still eligible
+// to be loaded.  We must remove a shim lib from the list before
+// we load the library to avoid recursive loops (load shim libA
+// for libB where libA also links against libB).
+static linked_list_t<const ShimDescriptor> g_active_shim_libs;
+
+static void reset_g_active_shim_libs(void) {
+  g_active_shim_libs.clear();
+  for (const auto& pair : g_ld_all_shim_libs) {
+    g_active_shim_libs.push_back(&pair);
+  }
+}
+
+void parse_LD_SHIM_LIBS(const char* path) {
+  g_ld_all_shim_libs.clear();
+  if (path != nullptr) {
+    for (const auto& pair : android::base::Split(path, ":")) {
+      std::vector<std::string> pieces = android::base::Split(pair, "|");
+      if (pieces.size() != 2) continue;
+      // If the path can be resolved, resolve it
+      char buf[PATH_MAX];
+      std::string resolved_path = pieces[0];
+      if (access(pieces[0].c_str(), R_OK) != 0) {
+        if (errno == ENOENT) {
+          // no need to test for non-existing path. skip.
+          continue;
+        }
+        // If not accessible, don't call realpath as it will just cause
+        // SELinux denial spam. Use the path unresolved.
+      } else if (realpath(pieces[0].c_str(), buf) != nullptr) {
+        resolved_path = buf;
+      }
+      auto desc = std::pair<std::string, std::string>(resolved_path, pieces[1]);
+      g_ld_all_shim_libs.push_back(desc);
+    }
+  }
+  reset_g_active_shim_libs();
+}
+
+std::vector<const ShimDescriptor*> shim_matching_pairs(const char* path) {
+  std::vector<const ShimDescriptor*> matched_pairs;
+
+  g_active_shim_libs.for_each([&](const ShimDescriptor* a_pair) {
+    if (a_pair->first == path) {
+      matched_pairs.push_back(a_pair);
+    }
+  });
+
+  g_active_shim_libs.remove_if([&](const ShimDescriptor* a_pair) {
+    return a_pair->first == path;
+  });
+
+  return matched_pairs;
+}
+#endif
+
 // This function walks down the tree of soinfo dependencies
 // in breadth-first order and
 //   * calls action(soinfo* si) for each node, and
@@ -1277,6 +1339,12 @@ static bool load_library(android_namespace_t* ns,
   if (si->get_dt_runpath().empty()) {
     si->set_dt_runpath("$ORIGIN/../lib64:$ORIGIN/lib64");
   }
+#endif
+
+#ifdef LD_SHIM_LIBS
+  for_each_matching_shim(realpath.c_str(), [&](const char* name) {
+    load_tasks->push_back(LoadTask::create(name, si, ns, task->get_readers_map()));
+  });
 #endif
 
   for_each_dt_needed(task->get_elf_reader(), [&](const char* name) {
@@ -2181,6 +2249,9 @@ void* do_dlopen(const char* name, int flags,
   }
 
   ProtectedDataGuard guard;
+#ifdef LD_SHIM_LIBS
+  reset_g_active_shim_libs();
+#endif
   soinfo* si = find_library(ns, translated_name, flags, extinfo, caller);
   loading_trace.End();
 

--- a/linker/linker.h
+++ b/linker/linker.h
@@ -42,6 +42,10 @@
 #include "linker_logger.h"
 #include "linker_soinfo.h"
 
+#ifdef LD_SHIM_LIBS
+#include "linker_debug.h"
+#endif
+
 #include <string>
 #include <vector>
 
@@ -76,6 +80,22 @@ soinfo* get_libdl_info(const soinfo& linker_si);
 soinfo* find_containing_library(const void* p);
 
 int open_executable(const char* path, off64_t* file_offset, std::string* realpath);
+
+#ifdef LD_SHIM_LIBS
+typedef std::pair<std::string, std::string> ShimDescriptor;
+void parse_LD_SHIM_LIBS(const char* path);
+std::vector<const ShimDescriptor*> shim_matching_pairs(const char* path);
+
+template<typename F>
+void for_each_matching_shim(const char* path, F action) {
+  if (path == nullptr) return;
+  INFO("Finding shim libs for \"%s\"", path);
+  for (const auto& one_pair : shim_matching_pairs(path)) {
+    INFO("Injecting shim lib \"%s\" as needed for %s", one_pair->second.c_str(), path);
+    action(one_pair->second.c_str());
+  }
+}
+#endif
 
 void do_android_get_LD_LIBRARY_PATH(char*, size_t);
 void do_android_update_LD_LIBRARY_PATH(const char* ld_library_path);

--- a/linker/linker_main.cpp
+++ b/linker/linker_main.cpp
@@ -417,6 +417,11 @@ static ElfW(Addr) linker_main(KernelArgumentBlock& args, const char* exe_to_load
   parse_LD_LIBRARY_PATH(ldpath_env);
   parse_LD_PRELOAD(ldpreload_env);
 
+#ifdef LD_SHIM_LIBS
+  // Read from TARGET_LD_SHIM_LIBS
+  parse_LD_SHIM_LIBS(LD_SHIM_LIBS);
+#endif
+
   std::vector<android_namespace_t*> namespaces = init_default_namespaces(exe_info.path.c_str());
 
   if (!si->prelink_image()) __linker_cannot_link(g_argv[0]);
@@ -441,6 +446,12 @@ static ElfW(Addr) linker_main(KernelArgumentBlock& args, const char* exe_to_load
     needed_library_name_list.push_back(ld_preload_name.c_str());
     ++ld_preloads_count;
   }
+
+#ifdef LD_SHIM_LIBS
+  for_each_matching_shim(si->get_realpath(), [&](const char* name) {
+    needed_library_name_list.push_back(name);
+  });
+#endif
 
   for_each_dt_needed(si, [&](const char* name) {
     needed_library_name_list.push_back(name);


### PR DESCRIPTION
Author: Christopher R. Palmer <crpalmer@gmail.com>
Date:   Tue Nov 3 16:44:44 2015 -0500

    linker: Add support for dynamic "shim" libs

    Add a new environment variable

    LD_SHIM_LIBS

    that is a colon (":") separated list of vertical bar ("|") separated pairs.
    The pairs are the name for a soinfo reference (executable or shared library)
    followed by the name of the shim library to load.  For example:

    LD_SHIM_LIBS=rmt_storage|libshim_ioprio.so:/system/lib/libicuuv.so|libshim_icu53.so

    will instruct the linker to load the dynamic library libshim_ioprio.so
    whenver rmt_storage is executed [*] and will load libshim_icu53.so whenever
    any executable or other shared library links against /system/lib/libicuuv.so.

    There are no restrictions against circular references.  In this example,
    libshim_icu53.so can link against libicuuv.so which provides a simple and
    convenient means of adding compatibility symbols.

    [*] Note that the absolute path is not available to the linker and therefore
    using the name of executables does depend on the invocation and therefore
    should only be used if absolutely necessary.  That is, running
    /system/bin/rmt_storage would not load any shim libs in this example because
    it does not match the name of the invocation of the command.

    If you have trouble determining the sonames being loaded, you can also set
    the environment variable LD_DEBUG=1 which will cause additional information
    to be logged to help trace the detection of the shim libs.

    Change-Id: I0ef80fa466167f7bcb7dac90842bef1c3cf879b6

Author: Christopher R. Palmer <crpalmer@gmail.com>
Date:   Sun Nov 15 14:26:32 2015 -0500

    linker: Fix the fact that shim libs do not properly call constructors

    Change-Id: I34333e13443a154e675b853fa41442351bc4243a

Author: Christopher R. Palmer <crpalmer@gmail.com>
Date:   Tue Dec 1 07:10:36 2015 -0500

    linker: Don't try to walk the g_active_shim_libs when doing dlsym

    This is a bug in the original shim_lib implementation which was
    doing the shim lib resolution both when loading the libraries
    and when doing the dynamic symbol resolution.

    Change-Id: Ib2df0498cf551b3bbd37d7c351410b9908eb1795

Author: Christopher R. Palmer <crpalmer@gmail.com>
Date:   Sun Nov 29 08:28:10 2015 -0500

    linker: Reset the active shim libs each time we do a dlopen

    We use the active libs to avoid recursively trying to load the
    same library:

    A -> shimlibs add B -> depends on A -> shimlibs add B -> ...

    However, when we repeatedly dlopen the same library we need
    to reset the active shim libs to avoid failing to add B the
    second time we dlopen A.

    Change-Id: I27580e3d6a53858e8bca025d6c85f981cffbea06

Author: Danny Baumann <dannybaumann@web.de>
Date:   Fri Dec 11 10:29:16 2015 +0100

    Make shim lib load failure non-fatal.

    Instead, print an appropriate warning message. Aborting symbol
    resolution on shim lib load failure leads to weird symbol lookup
    failures, because symbols in libraries referenced after the one loading
    the shim won't be loaded anymore without a log message stating why that
    happened.

    Change-Id: Ic3ad7095ddae7ea1039cb6a18603d5cde8a16143

Author: Christopher R. Palmer <crpalmer@gmail.com>
Date:   Sat Dec 12 06:10:09 2015 -0500

    bionic: Do not allow LD_SHIM_LIBS for setuid executables

    That's really not safe...

    Change-Id: If79af951830966fc21812cd0f60a8998a752a941

Author: Christopher R. Palmer <crpalmer@gmail.com>
Date:   Sun Feb 14 11:38:44 2016 -0500

    bionic: linker: Load shim libs *before* the self-linked libs

    By loading them earlier, this allows us to override a symbol in
    a library that is being directly linked.

    I believe this explains why some people have had problems shimming
    one lib but when the changet he shim to be against a different
    lib it magically works.

    It also makes it possible to override some symbols that were
    nearly impossible to override before this change.  For example, it is
    pretty much impossible to override a symbol in libutils without
    this change because it's loaded almost everywhere so no matter
    where you try to place the shimming, it will be too late and
    the other symbol will have priority.

    In particularly, this is necessary to be able to correctly
    shim the VectorImpl symbols for dlx.

    Change-Id: I461ca416bc288e28035352da00fde5f34f8d9ffa

Author: Chirayu Desai <chirayudesai1@gmail.com>
Date:   Thu Aug 25 19:02:41 2016 +0530

    linker: Update find_library call for shimlibs

    commits 0cdef7e7f3c6837b56a969120d9098463d1df8d8
    "Respect caller DT_RUNPATH in dlopen()."
    and 42d5fcb9f494eb45de3b6bf759f4a18076e84728
    "Introducing linker namespaces"
    added new arguments to find_library, add them here.

    Change-Id: I8f35a45b00d14f8b2ce01a0a96d2dc7759be04a6

Author: Chippa-a <vusal1372@gmail.com>
Date:   Sat Aug 27 14:56:30 2016 +0200

    linker: Update LD_SHIM_LIBS parser function

     * Upgrade the code using the same changes as
        42d5fcb9f494eb45de3b6bf759f4a18076e84728
        bda20e78f0f314dbbf0f0bbcf0740cf2d6a4b85e

    Change-Id: Ic8be0871945bd9feccd0f94a6770f3cc78a70a0f

Author: Danny Baumann <dannybaumann@web.de>
Date:   Wed Sep 7 16:54:06 2016 +0200

    Inject shim libs as if they were DT_NEEDED.

    The previous separate approach had one flaw: If the shim lib requires
    another lib that's already loaded, find_library_internal() would return
    the previously loaded copy, but the later load action would fail as the
    ELF reader map of the initial loading round was already discarded and
    thus a new ElfReader instance for the soinfo instance was created, which
    didn't know about the previous reading/loading state.

    Change-Id: Ib224dbd35d114197097e3dee14a077cc9130fedb

Author: jrior001 <jriordan001@gmail.com>
Date:   Fri Oct 7 19:36:51 2016 -0400

    linker: load shims prior to DT_NEEDED check

    This allows shims to override existing symbols, not just
    inject new symbols.

    Change-Id: Ib9216bcc651d8d38999c593babb94d76dc1dbc95

Author: Adrian DC <radian.dc@gmail.com>
Date: Sat, 8 Apr 2017 22:40:01 +0200

     * Adapt to latest AOSP Oreo bionic linker changes
     * Additional header to avoid unused function

    Change-Id: Ib9216bcc651d8d38999c593babb94d76dc1dbc95

Author: Paul Keith <javelinanddart@gmail.com>
Date:   Thu Feb 15 21:57:33 2018 +0100

    linker: Move shims to TARGET_LD_SHIM_LIBS

    * To reduce security exposure, let's set this at compile time,
      and block off all the code unless the board flag is set

    Change-Id: Ieec5f5d9e0f39a798fd48eae037ecffe9502474c

Author: Nich <nctrenco@gmail.com>
Date:   Fri Jun 8 09:48:17 2018 +0800

    linker: Provide soinfo path of the shimmed binary

    This is a forward port of part of the original change that was missed out
    since the initial port of the shim logic to O.

    Change-Id: I1f7ff98472cfef5cb2d2bcb303082784898cd0c6

Author: Nich <nctrenco@gmail.com>
Date:   Tue Jun 5 13:36:43 2018 +0800

    linker: Remove unused find_libraries declaration

    commit "Inject shim libs as if they were DT_NEEDED." removed references
    to the forward declaration.

    Change-Id: I5f1aaa3a96f2af3edef07d4ea4e204b586424631

Author: Nich <nctrenco@gmail.com>
Date:   Sun Jun 10 00:45:51 2018 +0800

    linker: Make shim reference path absolute

    This way, we can filter out non-existent binaries, and ensure we get
    its absolute path before matching with get_realpath(). This for one
    allows the use of symlinks in TARGET_LD_SHIM_LIBS.

    Change-Id: I823815271b3257965534b6b87d8ea36ffb68bc08

Author: Nich <nctrenco@gmail.com>
Date:   Fri Jun 15 03:59:05 2018 +0800

    linker: Ensure active matching pairs

    Change-Id: I54c666b4560dbfb40839b0bf9132a7fd8d3ed2dd

Author: Nich <nctrenco@gmail.com>
Date:   Thu Jun 21 01:58:10 2018 +0800

    linker: Don't involve shim in for_each_dt_needed

    for_each_dt_needed may have other usages that shouldn't involve the
    shim, for example, in the unloading of soinfos.

    Change-Id: Id38de183d90c3f707767bdca032a5ea2bc82fde8

Author: Jiyong Park <jiyong@google.com>
Date:   Fri Jan 25 18:18:01 2019 +0900

    Call realpath(3) only when the path is accessible for read

    Suppress the SELinux denial log spam by not calling realpath(3) when the
    path does not exist or is not accessible for read, and then not auditing
    access(2) failure.

    Change-Id: I729ecb8ea0bb581069eb849bae7cd28e6ab636cc

Change-Id: Ic3ad7095ddae7ea1039cb6a18603d5cde8a16152
Signed-off-by: Wang Han <416810799@qq.com>